### PR TITLE
Modified landing page to render blog excerpts rather than full blog posts

### DIFF
--- a/public/classes/BlogEngine.php
+++ b/public/classes/BlogEngine.php
@@ -65,7 +65,7 @@ class BlogEngine {
 
 		// Convert blogs from XML to HTML and add them to the HTML blog stack
 		foreach($blogsXML as $blogXML) {
-			$blogHTML = $this->xmlEngine->convertXMLBlogToHTML($blogXML);
+			$blogHTML = $this->xmlEngine->getBlogExcerptHTML($blogXML);
 			array_push($blogsHTML, $blogHTML);
 		}
 

--- a/public/classes/XMLEngine.php
+++ b/public/classes/XMLEngine.php
@@ -140,7 +140,23 @@ class XMLEngine {
 	// ---------------------------------------------------------------------------
 
 	// ---------------------------------------------------------------------------
-	// Method     : convertXMLBlogToHTML()
+	// ---------------------------------------------------------------------------
+	public function getBlogHTML($blog) {
+		return $this->convertXMLBlogDataToHTML($blog, 'content');
+	}
+	// ---------------------------------------------------------------------------
+
+	// ---------------------------------------------------------------------------
+	// ---------------------------------------------------------------------------
+	public function getBlogExcerptHTML($blog) {
+		return $this->convertXMLBlogDataToHTML($blog, 'excerpt');
+	}
+	// ---------------------------------------------------------------------------
+	// ---------------------------------------------------------------------------
+
+	// ----------------------- Private Interface ---------------------------------
+	// ---------------------------------------------------------------------------
+	// Method     : convertXMLBlogDataToHTML()
 	// Engineer   : Christian Westbrook
 	// Parameters : $blog - A dictionary holding an individual blog's XML tags
 	//              mapped to their respective content.
@@ -151,7 +167,7 @@ class XMLEngine {
 	//              predefined HTML template representing a blog post. This HTML
 	//              content is then returned as a string.
 	// ---------------------------------------------------------------------------
-	public function convertXMLBlogToHTML($blog) {
+	private function convertXMLBlogDataToHTML($blog, $content_key) {
 		# Append all desired HTML content to this string
 		$transformation = '';
 
@@ -170,7 +186,7 @@ class XMLEngine {
 
 		# Body
 		$transformation .= '<div class="content">';
-		$content = $blog['content'];
+		$content = $blog[$content_key];
 
 		$lines = explode("\n", $content);
 
@@ -311,9 +327,7 @@ class XMLEngine {
 		return $transformation;
 	}
 	// ---------------------------------------------------------------------------
-	// ---------------------------------------------------------------------------
 
-	// ----------------------- Private Interface --------------------------------
 	// ---------------------------------------------------------------------------
 	// Method     : generateSortableDateTime()
 	// Engineer   : Christian Westbrook


### PR DESCRIPTION
I renamed convertXMLBlogToHTML() to convertXMLBlogDataToHTML() and made it a part of the XMLEngine private interface rather than its public interface. I then made an adjustment so that convertXMLBlogDataToHTML() can be configured to grab either the entire blog or just its excerpt. This improvement will make it easier to develop blog excerpts and permanent blog pages separately.

I added two new public methods called getBlogHTML() and getBlogExcerptHTML() to XMLEngine's public interface that will get HTML for either a full blog post or a blog's excerpt. These public functions are currently coupled too tightly with convertXMLBlogDataToHTML(). A follow-on task should improve this interaction. This pull request closes #27 